### PR TITLE
ugettext_lazy -> gettext_lazy

### DIFF
--- a/imagestore/apps.py
+++ b/imagestore/apps.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 from __future__ import unicode_literals
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class ImagestoreConfig(AppConfig):

--- a/imagestore/forms.py
+++ b/imagestore/forms.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     FutureModelForm = forms.ModelForm
     AUTOCOMPLETE_LIGHT_INSTALLED = False
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 Image = swapper.load_model('imagestore', 'Image')
 Album = swapper.load_model('imagestore', 'Album')
 

--- a/imagestore/imagestore_cms/cms_app.py
+++ b/imagestore/imagestore_cms/cms_app.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 from cms.app_base import CMSApp
 from cms.apphook_pool import apphook_pool
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class ImagestoreApp(CMSApp):

--- a/imagestore/imagestore_cms/cms_plugins.py
+++ b/imagestore/imagestore_cms/cms_plugins.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 from .models import ImagestoreAlbumPtr, ImagestoreAlbumCarousel
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.conf import settings
 
 

--- a/imagestore/imagestore_cms/models.py
+++ b/imagestore/imagestore_cms/models.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from cms.models import CMSPlugin
 from django.db import models
 import swapper
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.conf import settings
 
 

--- a/imagestore/models/album.py
+++ b/imagestore/models/album.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import swapper
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from .bases.album import BaseAlbum
 
 

--- a/imagestore/models/bases/album.py
+++ b/imagestore/models/bases/album.py
@@ -8,7 +8,7 @@ from django.db import models
 # from django.db.models import permalink
 from django.urls import reverse
 from six import python_2_unicode_compatible
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from sorl.thumbnail import get_thumbnail
 from sorl.thumbnail.helpers import ThumbnailError
 

--- a/imagestore/models/bases/image.py
+++ b/imagestore/models/bases/image.py
@@ -10,7 +10,7 @@ from django.db import models
 from django.db.models.signals import post_save
 from django.urls import reverse
 from six import python_2_unicode_compatible
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from sorl.thumbnail import ImageField, get_thumbnail
 from sorl.thumbnail.helpers import ThumbnailError
 from tagging.fields import TagField

--- a/imagestore/models/image.py
+++ b/imagestore/models/image.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import swapper
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from .bases.image import BaseImage
 
 

--- a/imagestore/models/upload.py
+++ b/imagestore/models/upload.py
@@ -12,7 +12,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 logger = logging.getLogger(__name__)
 

--- a/imagestore/views.py
+++ b/imagestore/views.py
@@ -7,7 +7,7 @@ from django.shortcuts import get_object_or_404
 from django.http import Http404, HttpResponseRedirect
 from django.conf import settings
 from django.contrib.auth.decorators import permission_required, login_required
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import ListView, DetailView, CreateView, UpdateView, DeleteView
 from tagging.models import Tag, TaggedItem
 from tagging.utils import get_tag


### PR DESCRIPTION
Usuwa niepotrzebne wykorzystanie ugettext_lazy które było potrzebne w projektach z Python 2.

Projekty (oraz branche) które z tego korzystają:
https://github.com/webtechnika/osrodekwarzenko.pl/tree/master3.6
https://github.com/webtechnika/mlewandowska.pl

Sam import ugettext_lazy jak i gettext_lazy działają naprzemiennie w starych wersjach Django 1.xx, 2.xx. Jako że potrzebuję wsparcia na wersji 3.xx (i ktoś może korzystać w górę) to wywołanie importu z `u` jest zbędne a nawet powoduje wyjątek.